### PR TITLE
feat: 🎸 Add option to quick disable module

### DIFF
--- a/predictive_tap_hold/README.md
+++ b/predictive_tap_hold/README.md
@@ -100,6 +100,17 @@ Alternatively, you can implement the `pth_get_side` function, as shown in the [*
 
 ✅ Your keyboard is now ready to be compiled and flashed.
 
+### Disabling
+
+If you want to temporarily turn off this module functionality without reverting all changes above, include this on your `config.h`:
+
+```c
+#define PTH_DISABLED
+
+```
+
+You will probably want to set TAPPING_TERM to its previous value as well.
+
 ### Usage with QMK's Tap-Hold Logic
 
 You don't have to go all-in. You can use PTH for some keys and QMK's standard `TAPPING_TERM` logic for others.

--- a/predictive_tap_hold/predictive_tap_hold.c
+++ b/predictive_tap_hold/predictive_tap_hold.c
@@ -269,6 +269,10 @@ static void reset_pth_state(void) {
 }
 
 void keyboard_post_init_predictive_tap_hold(void) {
+#ifdef PTH_DISABLED
+    uprintf("Predictive_tap_hold is disabled");
+    return;
+#endif
     // since we have no data yet, just use one far in the past
     press_to_press_timer = timer_read() - MS_MAX_DUR_FOR_TIMERS;
     release_timer        = timer_read() - (MS_MAX_DUR_FOR_TIMERS - 100);
@@ -1594,6 +1598,9 @@ static void collect_new_press_to_press_and_overlap_duration(bool is_pressed, uin
 // Core Processing Function (State Machine)
 // ----------------------------------------------------------------------------
 bool process_record_predictive_tap_hold(uint16_t keycode, keyrecord_t* record) {
+#ifdef PTH_DISABLED
+    return true;
+#endif
     // Initial checks - don't handle internal events or non-key events
     if (is_processing_record_due_to_pth || !IS_KEYEVENT(record->event)) {
         return true; // let the processing continue
@@ -2033,6 +2040,9 @@ bool process_record_predictive_tap_hold(uint16_t keycode, keyrecord_t* record) {
 // Housekeeping (runs constantly)
 // ----------------------------------------------------------------------------
 void housekeeping_task_predictive_tap_hold(void) {
+#ifdef PTH_DISABLED
+    return;
+#endif
     uint16_t cur_time = timer_read();
 
     if (!release_timer_max_reached) {

--- a/predictive_tap_hold/predictive_tap_hold.c
+++ b/predictive_tap_hold/predictive_tap_hold.c
@@ -14,16 +14,17 @@
 
 #include "predictive_tap_hold.h"
 
-#ifdef NO_ACTION_TAPPING
-#    error "This feature requires action tapping. Please update your config.h"
-#endif
+#ifndef PTH_DISABLED
+    #ifdef NO_ACTION_TAPPING
+    #    error "This feature requires action tapping. Please update your config.h"
+    #endif
 
-#if !defined(TAPPING_TERM) && !defined(TAPPING_TERM_PER_KEY)
-#    error "Predictive Tap-Hold requires TAPPING_TERM = 0 or TAPPING_TERM_PER_KEY to be defined. Please update your config.h"
-#elif defined(TAPPING_TERM) && !defined(TAPPING_TERM_PER_KEY) && TAPPING_TERM != 0
-#    error "Predictive Tap-Hold requires TAPPING_TERM = 0 or TAPPING_TERM_PER_KEY to be defined. Please update your config.h"
-#endif
-
+    #if !defined(TAPPING_TERM) && !defined(TAPPING_TERM_PER_KEY)
+    #    error "Predictive Tap-Hold requires TAPPING_TERM = 0 or TAPPING_TERM_PER_KEY to be defined. Please update your config.h"
+    #elif defined(TAPPING_TERM) && !defined(TAPPING_TERM_PER_KEY) && TAPPING_TERM != 0
+    #    error "Predictive Tap-Hold requires TAPPING_TERM = 0 or TAPPING_TERM_PER_KEY to be defined. Please update your config.h"
+    #endif
+#endif /* ifndef PTH_DISABLED */
 /*
 Here is the structure of a record for reference:
 


### PR DESCRIPTION
If you want to temporarily turn off this module functionality without reverting all installation changes.
It can be handy when doing some debugging and you want to isolate any possible side effects that could be related to this module.